### PR TITLE
Update Cms.php

### DIFF
--- a/src/app/code/community/Mbiz/Setup/Model/Cms.php
+++ b/src/app/code/community/Mbiz/Setup/Model/Cms.php
@@ -173,6 +173,7 @@ class Mbiz_Setup_Model_Cms extends Mage_Core_Model_Abstract
 
         $page = Mage::getModel('cms/page')
             ->setStores($data['stores'])
+            ->setStoreId(array_pop($data['stores']))
             ->load($data['identifier'], 'identifier');
 
         return $page->addData($data)


### PR DESCRIPTION
In case of a page identifier is assigned to multiple stores and exist multiple times, an issue happen `A page URL key for specified store already exists.`. The reason is because the store_id is missing into the CMS Page object and the resource method _getLoadSelect is skipped. The filtering is not enough sufficient and the object is instanciated not with appropriate data

```
{
    {
      "identifier": "home",
      "is_active": 1,
      "content_file": "home_de.html",
      "stores": [
        "mywebsite",
        "mywebsite_1"
      ]
    }
}
```